### PR TITLE
[Feat] getRecordByUser

### DIFF
--- a/src/constant/responseMessage.ts
+++ b/src/constant/responseMessage.ts
@@ -48,4 +48,6 @@ export default {
   NO_RECORD_TIME: "경로 뛴 시간 없음",
   NO_RECORD_PACE: "경로 뛴 페이스 없음",
   NO_COURSE_ID: "코스아이디 없음",
+  NO_RECORD: "유저의 러닝 기록이 없음",
+  READ_RECORD_SUCCESS: "활동 기록 조회 성공",
 };

--- a/src/controller/recordController.ts
+++ b/src/controller/recordController.ts
@@ -5,11 +5,14 @@ import { validationResult } from "express-validator";
 import {
   timestampConvertString,
   stringConvertTime,
+  dateConvertString,
 } from "../module/convert/convertTime";
 import { recordService } from "../service";
 import {
   recordRequestDTO,
   recordResponseDTO,
+  getRecordByUserResponseDTO,
+  records,
 } from "./../interface/DTO/recordDTO";
 
 const createRecord = async (req: Request, res: Response) => {
@@ -82,5 +85,56 @@ const createRecord = async (req: Request, res: Response) => {
   }
 };
 
-const recordController = { createRecord };
+const getRecordByUser = async (req: Request, res: Response) => {
+  const error = validationResult(req);
+  if (!error.isEmpty()) {
+    const validationErrorMsg = error["errors"][0].msg;
+    return res
+      .status(sc.BAD_REQUEST)
+      .send(fail(sc.BAD_REQUEST, validationErrorMsg));
+  }
+  const machineId = req.header("machineId") as string;
+  try {
+    const getRecordByUser = await recordService.getRecordByUser(machineId);
+    if (!getRecordByUser) {
+      return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.NO_USER));
+    } else {
+      const recordsArray: records[] = getRecordByUser.map((pc: any) => {
+        let record: records = {
+          id: pc.id,
+          courseId: pc.Course.id,
+          publicCourseId: pc.public_course_id,
+          machineId: machineId,
+          title: pc.title,
+          image: pc.Course.image,
+          createdAt: timestampConvertString(pc.created_at),
+          distance: pc.Course.distance,
+          time: dateConvertString(pc.time).substring(11, 19),
+          pace: dateConvertString(pc.pace).substring(11, 19),
+          departure: {
+            region: pc.Course.departure_region,
+            city: pc.Course.departure_city,
+          },
+        };
+        return record;
+      });
+      const getRecordByUserResponseDTO: getRecordByUserResponseDTO = {
+        user: { machineId: machineId },
+        records: recordsArray,
+      };
+      return res
+        .status(sc.OK)
+        .send(
+          success(sc.OK, rm.READ_RECORD_SUCCESS, getRecordByUserResponseDTO)
+        );
+    }
+  } catch (error) {
+    console.log(error);
+    return res
+      .status(sc.INTERNAL_SERVER_ERROR)
+      .send(fail(sc.INTERNAL_SERVER_ERROR, rm.INTERNAL_SERVER_ERROR));
+  }
+};
+
+const recordController = { createRecord, getRecordByUser };
 export default recordController;

--- a/src/interface/DTO/recordDTO.ts
+++ b/src/interface/DTO/recordDTO.ts
@@ -13,3 +13,27 @@ export interface recordResponseDTO {
     createdAt: string;
   };
 }
+
+export interface records {
+  id: number;
+  courseId: number;
+  publicCourseId?: number;
+  machineId: string;
+  title: string;
+  image: string;
+  createdAt: string;
+  distance: number;
+  time: string;
+  pace: string;
+  departure: {
+    region: string;
+    city: string;
+  };
+}
+
+export interface getRecordByUserResponseDTO {
+  user: {
+    machineId: string;
+  };
+  records: records[];
+}

--- a/src/router/recordRouter.ts
+++ b/src/router/recordRouter.ts
@@ -28,4 +28,14 @@ recordRouter.post(
   recordController.createRecord
 );
 
+recordRouter.get(
+  "/user",
+  [
+    header("machineId")
+      .notEmpty()
+      .withMessage("기기넘버가 없음"),
+  ],
+  recordController.getRecordByUser
+);
+
 export default recordRouter;

--- a/src/service/recordService.ts
+++ b/src/service/recordService.ts
@@ -25,8 +25,39 @@ const createRecord = async (recordRequestDTO: recordRequestDTO) => {
   }
 };
 
-const recordService = {
-  createRecord,
+const getRecordByUser = async (machineId: string) => {
+  try {
+    const userData = await prisma.user.findUnique({
+      where: { machine_id: machineId },
+    });
+    if (!userData) {
+      return null;
+    } else {
+      const recordData = await prisma.record.findMany({
+        where: { user_machine_id: machineId },
+        include: {
+          Course: {
+            include: {
+              User: true,
+            },
+          },
+        },
+        orderBy: {
+          created_at: "desc", // 최신순이니까 desc
+        },
+      });
+      if (!recordData) {
+        return [];
+      } else {
+        return recordData;
+      }
+    }
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
 };
+
+const recordService = { createRecord, getRecordByUser };
 
 export default recordService;


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---
closes #19 
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->

### 🤔 어떻게 이슈를 해결했나요?

---

- machineId를 받아 존재하는 유저면 record테이블을 조회한다.
- record 데이터를 내림차순으로 받아온다.

### 🤯 주의할 점이 있나요?

---
- 유저가 존재하나 record데이터가 없을 때는 빈배열을 response 받아오도록 했다.
<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
