### PR TITLE
[Feat] createAndDeleteScrap

### DIFF
--- a/src/constant/responseMessage.ts
+++ b/src/constant/responseMessage.ts
@@ -54,4 +54,9 @@ export default {
   NO_COURSE_ID: "코스아이디 없음",
   NO_RECORD: "유저의 러닝 기록이 없음",
   READ_RECORD_SUCCESS: "활동 기록 조회 성공",
+
+  //scrap
+  CREATE_SCRAP_SUCCESS: "코스 스크랩 성공",
+  DELETE_SCRAP_SUCCESS: "코스 스크랩 취소 성공",
+  INVALID_USER: "유효하지 않은 유저",
 };

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -1,3 +1,4 @@
 export { default as publicCourseController } from "./publicCourseController";
 export { default as courseController } from "./courseController";
 export { default as recordController } from "./recordController";
+export { default as scrapController } from "./scrapController";

--- a/src/controller/scrapController.ts
+++ b/src/controller/scrapController.ts
@@ -1,0 +1,56 @@
+import { Request, Response } from "express";
+import { rm, sc } from "../constant";
+import { success, fail } from "../constant/response";
+import { validationResult } from "express-validator";
+import { scrapService } from "../service";
+import { scrapDTO } from "./../interface/DTO/scrapDTO";
+
+const createAndDeleteScrap = async (req: Request, res: Response) => {
+  const error = validationResult(req);
+  if (!error.isEmpty()) {
+    const validationErrorMsg = error["errors"][0].msg;
+    return res
+      .status(sc.BAD_REQUEST)
+      .send(fail(sc.BAD_REQUEST, validationErrorMsg));
+  }
+  const machineId = req.header("machineId") as string;
+  const { publicCourseId, scrapTF } = req.body;
+  const scrapDTO: scrapDTO = {
+    machineId: machineId,
+    publicCourseId: +publicCourseId,
+    scrapTF: scrapTF,
+  };
+  try {
+    if (scrapTF == true) {
+      const createScrap = await scrapService.createScrap(scrapDTO);
+      if (!createScrap) {
+        return res
+          .status(sc.BAD_REQUEST)
+          .send(fail(sc.BAD_REQUEST, rm.BAD_REQUEST));
+      } else if (createScrap == "NoUser") {
+        return res
+          .status(sc.BAD_REQUEST)
+          .send(fail(sc.BAD_REQUEST, rm.INVALID_USER));
+      } else {
+        return res.status(sc.OK).send(success(sc.OK, rm.CREATE_SCRAP_SUCCESS));
+      }
+    } else {
+      const deleteScrap = await scrapService.deleteScrap(scrapDTO);
+      if (!deleteScrap) {
+        return res
+          .status(sc.BAD_REQUEST)
+          .send(fail(sc.BAD_REQUEST, rm.BAD_REQUEST));
+      } else {
+        return res.status(sc.OK).send(success(sc.OK, rm.DELETE_SCRAP_SUCCESS));
+      }
+    }
+  } catch (error) {
+    console.log(error);
+    return res
+      .status(sc.INTERNAL_SERVER_ERROR)
+      .send(fail(sc.INTERNAL_SERVER_ERROR, rm.INTERNAL_SERVER_ERROR));
+  }
+};
+
+const scrapController = { createAndDeleteScrap };
+export default scrapController;

--- a/src/interface/DTO/scrapDTO.ts
+++ b/src/interface/DTO/scrapDTO.ts
@@ -1,0 +1,5 @@
+export interface scrapDTO {
+  machineId: string;
+  publicCourseId: number;
+  scrapTF: boolean;
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,11 +2,13 @@ import { Router } from "express";
 import publicCourseRouter from "./publicCourseRouter";
 import courseRouter from "./courseRouter";
 import recordRouter from "./recordRouter";
+import scrapRouter from "./scrapRouter";
 
 const router: Router = Router();
 
 router.use("/public-course", publicCourseRouter);
 router.use("/course", courseRouter);
 router.use("/record", recordRouter);
+router.use("/scrap", scrapRouter);
 
 export default router;

--- a/src/router/scrapRouter.ts
+++ b/src/router/scrapRouter.ts
@@ -15,6 +15,9 @@ scrapRouter.post(
       .withMessage("코스 아이디가 없음")
       .isNumeric()
       .withMessage("유효하지 않은 코스 아이디"),
+    body("scrapTF")
+      .notEmpty()
+      .withMessage("스크랩 여부가 없음"),
   ],
   scrapController.createAndDeleteScrap
 );

--- a/src/router/scrapRouter.ts
+++ b/src/router/scrapRouter.ts
@@ -1,0 +1,22 @@
+import { Router } from "express";
+import { body, header } from "express-validator";
+import { scrapController } from "../controller";
+
+const scrapRouter: Router = Router();
+
+scrapRouter.post(
+  "/",
+  [
+    header("machineId")
+      .notEmpty()
+      .withMessage("기기넘버가 없음"),
+    body("publicCourseId")
+      .notEmpty()
+      .withMessage("코스 아이디가 없음")
+      .isNumeric()
+      .withMessage("유효하지 않은 코스 아이디"),
+  ],
+  scrapController.createAndDeleteScrap
+);
+
+export default scrapRouter;

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -2,3 +2,4 @@ export { default as publicCourseService } from "./publicCourseService";
 export { default as courseService } from "./courseService";
 export { default as recordService } from "./recordService";
 export { default as stampService } from "./stampService";
+export { default as scrapService } from "./scrapService";

--- a/src/service/scrapService.ts
+++ b/src/service/scrapService.ts
@@ -4,40 +4,35 @@ const prisma = new PrismaClient();
 
 const createScrap = async (scrapDTO: scrapDTO) => {
   try {
-    const userData = await prisma.user.findUnique({
-      where: { machine_id: scrapDTO.machineId },
+    const scrapId = await prisma.scrap.findFirst({
+      where: {
+        user_machine_id: scrapDTO.machineId,
+        public_course_id: scrapDTO.publicCourseId,
+      },
+      select: {
+        id: true,
+      },
     });
-    if (!userData) {
-      return "NoUser";
+    console.log(scrapId);
+
+    if (scrapId) {
+      const scrapAgain = await prisma.scrap.update({
+        where: { id: scrapId["id"] },
+        data: { scrapTF: true },
+      });
+      return scrapAgain;
     } else {
-      const scrapId = await prisma.scrap.findMany({
-        where: {
+      const scrapData = await prisma.scrap.create({
+        data: {
           user_machine_id: scrapDTO.machineId,
           public_course_id: scrapDTO.publicCourseId,
-        },
-        select: {
-          id: true,
+          scrapTF: scrapDTO.scrapTF,
         },
       });
-      if (!(scrapId.length == 0)) {
-        const scrapAgain = await prisma.scrap.update({
-          where: { id: scrapId[0]["id"] },
-          data: { scrapTF: true },
-        });
-        return scrapAgain;
+      if (!scrapData) {
+        return null;
       } else {
-        const scrapData = await prisma.scrap.create({
-          data: {
-            user_machine_id: scrapDTO.machineId,
-            public_course_id: scrapDTO.publicCourseId,
-            scrapTF: scrapDTO.scrapTF,
-          },
-        });
-        if (!scrapData) {
-          return null;
-        } else {
-          return scrapData;
-        }
+        return scrapData;
       }
     }
   } catch (error) {
@@ -48,20 +43,27 @@ const createScrap = async (scrapDTO: scrapDTO) => {
 
 const deleteScrap = async (scrapDTO: scrapDTO) => {
   try {
-    const scrapId = await prisma.scrap.findMany({
+    const scrapId = await prisma.scrap.findFirst({
       where: {
-        user_machine_id: scrapDTO.machineId,
-        public_course_id: scrapDTO.publicCourseId,
+        AND: [
+          { user_machine_id: scrapDTO.machineId },
+          { public_course_id: scrapDTO.publicCourseId },
+        ],
       },
       select: {
         id: true,
       },
     });
-    const deleteScrap = await prisma.scrap.update({
-      where: { id: scrapId[0]["id"] },
-      data: { scrapTF: false },
-    });
-    return deleteScrap;
+
+    if (!scrapId) {
+      return null;
+    } else {
+      const deleteScrap = await prisma.scrap.update({
+        where: { id: scrapId["id"] },
+        data: { scrapTF: false },
+      });
+      return deleteScrap;
+    }
   } catch (error) {
     console.log(error);
     throw error;

--- a/src/service/scrapService.ts
+++ b/src/service/scrapService.ts
@@ -1,0 +1,56 @@
+import { PrismaClient } from "@prisma/client";
+import { scrapDTO } from "./../interface/DTO/scrapDTO";
+const prisma = new PrismaClient();
+
+const createScrap = async (scrapDTO: scrapDTO) => {
+  try {
+    const userData = await prisma.user.findUnique({
+      where: { machine_id: scrapDTO.machineId },
+    });
+    if (!userData) {
+      return "NoUser";
+    } else {
+      const scrapData = await prisma.scrap.create({
+        data: {
+          user_machine_id: scrapDTO.machineId,
+          public_course_id: scrapDTO.publicCourseId,
+          scrapTF: scrapDTO.scrapTF,
+        },
+      });
+      if (!scrapData) {
+        return null;
+      } else {
+        return scrapData;
+      }
+    }
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
+
+const deleteScrap = async (scrapDTO: scrapDTO) => {
+  try {
+    const scrapId = await prisma.scrap.findMany({
+      where: {
+        user_machine_id: scrapDTO.machineId,
+        public_course_id: scrapDTO.publicCourseId,
+      },
+      select: {
+        id: true,
+      },
+    });
+    const deleteScrap = await prisma.scrap.update({
+      where: { id: scrapId[0]["id"] },
+      data: { scrapTF: false },
+    });
+    return deleteScrap;
+  } catch (error) {
+    console.log(error);
+    throw error;
+  }
+};
+
+const scrapService = { createScrap, deleteScrap };
+
+export default scrapService;

--- a/src/service/scrapService.ts
+++ b/src/service/scrapService.ts
@@ -10,17 +10,34 @@ const createScrap = async (scrapDTO: scrapDTO) => {
     if (!userData) {
       return "NoUser";
     } else {
-      const scrapData = await prisma.scrap.create({
-        data: {
+      const scrapId = await prisma.scrap.findMany({
+        where: {
           user_machine_id: scrapDTO.machineId,
           public_course_id: scrapDTO.publicCourseId,
-          scrapTF: scrapDTO.scrapTF,
+        },
+        select: {
+          id: true,
         },
       });
-      if (!scrapData) {
-        return null;
+      if (!(scrapId.length == 0)) {
+        const scrapAgain = await prisma.scrap.update({
+          where: { id: scrapId[0]["id"] },
+          data: { scrapTF: true },
+        });
+        return scrapAgain;
       } else {
-        return scrapData;
+        const scrapData = await prisma.scrap.create({
+          data: {
+            user_machine_id: scrapDTO.machineId,
+            public_course_id: scrapDTO.publicCourseId,
+            scrapTF: scrapDTO.scrapTF,
+          },
+        });
+        if (!scrapData) {
+          return null;
+        } else {
+          return scrapData;
+        }
       }
     }
   } catch (error) {


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---
closes #39

<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->

### 🤔 어떻게 이슈를 해결했나요?

---

- scrapTF가 true일 때 createScrap, false일 때 deleteScrap을 실행하도록 했다.
- deleteScrap은 scrap테이블에서 해당 로우를 삭제하는 것이 아닌 scrapTF 속성을 false 바꾸는 방식으로 구현했다.
- scrapTF를 update할 때 where절에서 scrap테이블의 id값만을 받을 수 있는데 이는 request로 들어오지 않아서, machineId, publicCourseId와 일치하는 scrapId를 findMany로 찾아서 이용했다.

### 🤯 주의할 점이 있나요?

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
