### PR TITLE
[Fix] delete scrap관련 에러처리 로직 추가 (#76)

### DIFF
--- a/src/constant/responseMessage.ts
+++ b/src/constant/responseMessage.ts
@@ -70,6 +70,7 @@ export default {
   DELETE_SCRAP_SUCCESS: "코스 스크랩 취소 성공",
   INVALID_USER: "유효하지 않은 유저",
   READ_SCRAP_COURSE_SUCCESS: "스크랩한 코스 조회 성공",
+  NO_PUBLIC_COURSE_ID: "존재하지 않는 public course id입니다.",
 
   //stamp
   READ_STAMP_BY_USER: "유저가 가진 스탬프 조회 성공",

--- a/src/controller/scrapController.ts
+++ b/src/controller/scrapController.ts
@@ -34,6 +34,8 @@ const createAndDeleteScrap = async (req: Request, res: Response) => {
       const deleteScrap = await scrapService.deleteScrap(scrapDTO);
       if (!deleteScrap) {
         return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.BAD_REQUEST));
+      } else if (deleteScrap["count"]==0) {
+        return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.NO_PUBLIC_COURSE_ID));
       } else {
         return res.status(sc.OK).send(success(sc.OK, rm.DELETE_SCRAP_SUCCESS));
       }


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---
- issues #76
- delete scrap에서 없는 public course id를 입력했을 때 에러처리 해주는 로직 추가
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->

### 🤔 어떻게 이슈를 해결했나요?

---

- deletescrap에서 count 값을 0으로 주면 없는 public course id이므로 에러 처리 하도록 함

### 🤯 주의할 점이 있나요?

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
