### PR TITLE
[FIX] publicCourseDetail에서 userId가 null인 유저의 정보를 "알 수 없음"으로 전환

### DIFF
--- a/src/service/publicCourseService.ts
+++ b/src/service/publicCourseService.ts
@@ -108,6 +108,11 @@ const getPublicCourseDetail = async (userId: number, publicCourseId: number) => 
     const isPublicScrap = await prisma.scrap.findFirst({
       where: { user_id: userId, public_course_id: publicCourseId, scrapTF: true },
     });
+    if (publicCourseData[0].pcuid == null) {
+      publicCourseData[0].nickname = "알 수 없음";
+      publicCourseData[0].level = "알 수 없음";
+      publicCourseData[0].latest_stamp = "알 수 없음";
+    }
     const publicCourseDetailGetDTO: PublicCourseDetailGetDTO = {
       user: {
         nickname: publicCourseData[0].nickname,


### PR DESCRIPTION
#160

<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---
closes #160
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->

### 🤔 어떻게 이슈를 해결했나요?

---

- publicCourse의 작성자의 userId가 null일 때 닉네임, 레벨, 스탬프이미지를 "알 수 없음"으로 변경한 후 리턴

### 🤯 주의할 점이 있나요?

---
실제로 유저가 탈퇴했을 때 userId값이 null이 되는 것이라고 생각하고 작성했는데 맞는지 잘 모르겠습니다!!
의견 부탁드려용 ㅠ
<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
