### PR TITLE
[Feat] delete apple user

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -25,4 +25,14 @@ export default {
   s3AccessKey: process.env.S3_ACCESS_KEY as string,
   s3SecretKey: process.env.S3_SECRET_KEY as string,
   bucketName: process.env.S3_BUCKET as string,
+
+  //?구글소셜
+  googleClientId: process.env.GOOGLE_CLIENT_ID as string,
+  googleClientId2: process.env.GOOGLE_CLIENT_ID2 as string,
+
+  //?애플소셜
+  appleKeyId: process.env.APPLE_KEY_ID as string,
+  appleTeamId: process.env.APPLE_TEAM_ID as string,
+  appleBundleId: process.env.APPLE_BUNDLE_ID as string,
+  appleP8Path: process.env.APPLE_P8_PATH as string,
 };

--- a/src/constant/responseMessage.ts
+++ b/src/constant/responseMessage.ts
@@ -25,6 +25,7 @@ export default {
 
   // 소셜로그인
   READ_SOCIAL_FAIL: "소셜로그인 회원 정보 조회 실패",
+  WITHDRAW_APPLE_SOCIAL_FAIL: "애플 소셜회원 탈퇴 실패",
 
   // 코스
   READ_COURSE_SUCCESS: "코스 조회 성공",

--- a/src/controller/userController.ts
+++ b/src/controller/userController.ts
@@ -86,13 +86,14 @@ const deleteUser = async (req: Request, res: Response) => {
     return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, validationErrorMsg));
   }
   const refreshToken = req.header("refreshToken");
+  //!
+  const appleAccessToken = req.header("appleAccessToken");
 
   try {
-    const data = await userService.deleteUser(refreshToken!);
+    const data = await userService.deleteUser(refreshToken!, appleAccessToken);
     if (!data) return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.DELETE_USER_FAIL));
     else if (typeof data == "string") return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, data));
-    return res.status(sc.OK).send(success(sc.OK, rm.DELETE_USER_SUCCESS, { "deletedUserId" : data }));
-
+    return res.status(sc.OK).send(success(sc.OK, rm.DELETE_USER_SUCCESS, { deletedUserId: data }));
   } catch (e) {
     console.log(e);
     return res.status(sc.INTERNAL_SERVER_ERROR).send(fail(sc.INTERNAL_SERVER_ERROR, rm.INTERNAL_SERVER_ERROR));

--- a/src/controller/userController.ts
+++ b/src/controller/userController.ts
@@ -86,7 +86,7 @@ const deleteUser = async (req: Request, res: Response) => {
     return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, validationErrorMsg));
   }
   const refreshToken = req.header("refreshToken");
-  //!
+  //! 애플의 경우만 헤더에 appleAccessToken  보내기
   const appleAccessToken = req.header("appleAccessToken");
 
   try {

--- a/src/module/jwtHandler.ts
+++ b/src/module/jwtHandler.ts
@@ -2,6 +2,12 @@
 
 import jwt from "jsonwebtoken";
 import { tokenType } from "../constant";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import timezone from "dayjs/plugin/timezone";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 //* 받아온 userId를 담는 access token 생성
 const sign = (userId: number) => {
@@ -43,8 +49,34 @@ const verify = (token: string) => {
   return decoded;
 };
 
+const createAppleJWT = () => {
+  const p8Key = (process.env.APPLE_P8 as string).replace(/\\n/g, "\n");
+  const appleJWT = jwt.sign(
+    {
+      iss: process.env.APPLE_TEAM_ID,
+      iat: dayjs()
+        .tz()
+        .unix(),
+      exp:
+        dayjs()
+          .tz()
+          .unix() + 120,
+      aud: "https://appleid.apple.com",
+      sub: process.env.APPLE_BUNDLE_ID,
+    },
+    p8Key,
+    {
+      algorithm: "ES256",
+      header: {
+        alg: "ES256",
+        kid: process.env.APPLE_KEY_ID,
+      },
+    }
+  );
+};
 export default {
   sign,
   verify,
   createRefreshToken,
+  createAppleJWT,
 };

--- a/src/module/jwtHandler.ts
+++ b/src/module/jwtHandler.ts
@@ -5,6 +5,8 @@ import { tokenType } from "../constant";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import timezone from "dayjs/plugin/timezone";
+import config from "../config";
+import fs from "fs";
 
 dayjs.extend(utc);
 dayjs.extend(timezone);
@@ -50,30 +52,33 @@ const verify = (token: string) => {
 };
 
 const createAppleJWT = () => {
-  const p8Key = (process.env.APPLE_P8 as string).replace(/\\n/g, "\n");
-  const appleJWT = jwt.sign(
-    {
-      iss: process.env.APPLE_TEAM_ID,
-      iat: dayjs()
+  const p8Key = fs.readFileSync(config.appleP8Path, "utf8");
+
+  const payload = {
+    iss: config.appleTeamId,
+    iat: dayjs()
+      .tz()
+      .unix(),
+    exp:
+      dayjs()
         .tz()
-        .unix(),
-      exp:
-        dayjs()
-          .tz()
-          .unix() + 120,
-      aud: "https://appleid.apple.com",
-      sub: process.env.APPLE_BUNDLE_ID,
+        .unix() + 120,
+    aud: "https://appleid.apple.com",
+    sub: config.appleBundleId,
+  };
+
+  const appleJWT = jwt.sign(payload, p8Key, {
+    algorithm: "ES256",
+    header: {
+      alg: "ES256",
+      kid: config.appleKeyId,
     },
-    p8Key,
-    {
-      algorithm: "ES256",
-      header: {
-        alg: "ES256",
-        kid: process.env.APPLE_KEY_ID,
-      },
-    }
-  );
+  });
+  //!
+  //console.log("야ㅣ야이야이");
+  //console.log(appleJWT);
 };
+
 export default {
   sign,
   verify,

--- a/src/module/jwtHandler.ts
+++ b/src/module/jwtHandler.ts
@@ -74,9 +74,8 @@ const createAppleJWT = () => {
       kid: config.appleKeyId,
     },
   });
-  //!
-  //console.log("야ㅣ야이야이");
-  //console.log(appleJWT);
+
+  return appleJWT;
 };
 
 export default {

--- a/src/router/userRouter.ts
+++ b/src/router/userRouter.ts
@@ -48,12 +48,8 @@ router.patch(
 );
 
 router.delete(
+  //토큰 여부는 auth middleware에서 검사함
   "/",
-  [
-    header("refreshToken")
-      .notEmpty()
-      .withMessage("refreshToken이 없습니다."),
-  ],
   userController.deleteUser
 );
 

--- a/src/service/userService.ts
+++ b/src/service/userService.ts
@@ -216,13 +216,14 @@ const deleteUser = async (refreshToken: string, token?: string) => {
           },
         })
         .then(async (res) => {
+          console.log(res);
           if (res.status == 200) {
             console.log("애플 회원탈퇴 성공");
           }
         })
         .catch((error) => {
           console.log("애플 회원탈퇴 실패", error);
-          return rm.WITHDRAW_APPLE_SOCIAL_FAIL;
+          throw rm.WITHDRAW_APPLE_SOCIAL_FAIL;
         });
     }
 

--- a/src/service/userService.ts
+++ b/src/service/userService.ts
@@ -2,10 +2,12 @@ import { UpdatedUserGetDTO } from "../interface/DTO/user/UpdatedUserGetDTO";
 import { SocialCreateRequestDTO } from "./../interface/DTO/auth/SocialCreateDTO";
 import { UserGetDTO } from "../interface/DTO/user/UserGetDTO";
 import { randomInitialNickname } from "../module/randomInitialNickname";
+import { rm } from "../constant";
 
 import { PrismaClientKnownRequestError, PrismaClientValidationError } from "@prisma/client/runtime";
 import { PrismaClient } from "@prisma/client";
 import { dateConvertString } from "../module/convert/convertTime";
+import jwtHandler from "../module/jwtHandler";
 
 const prisma = new PrismaClient();
 
@@ -189,18 +191,23 @@ const updateUserNickname = async (userId: number, nickname: string) => {
 const deleteUser = async (refreshToken: string) => {
   try {
     const user = await getUserByRefreshToken(refreshToken);
-    if (!user) return `존재하지 않는 유저입니다.`;
+    if (!user) return rm.NO_USER;
 
+    //!
+    console.log(user);
+    if (user.provider === "APPLE") {
+      const clientSecret = jwtHandler.createAppleJWT();
+    }
+    /*
     const data = await prisma.user.delete({
       where: {
         id: user?.id,
       },
     });
-    return data.id;
-
+    return data.id;*/
   } catch (error) {
     if (error instanceof PrismaClientKnownRequestError && error.code == "P2025") {
-      return `존재하지 않는 유저입니다.`;
+      return rm.NO_USER;
     } else {
       console.log(error);
     }

--- a/src/service/userService.ts
+++ b/src/service/userService.ts
@@ -190,7 +190,7 @@ const updateUserNickname = async (userId: number, nickname: string) => {
   }
 };
 
-const deleteUser = async (refreshToken: string, code?: string, token?: string) => {
+const deleteUser = async (refreshToken: string, token?: string) => {
   try {
     const user = await getUserByRefreshToken(refreshToken);
     if (!user) return rm.NO_USER;
@@ -199,10 +199,8 @@ const deleteUser = async (refreshToken: string, code?: string, token?: string) =
     console.log(user);
 
     if (user.provider === "APPLE") {
-      //^ 이 경우만 request에서 code와 토큰 받아오기
-      //^ 일단 소셜로그인에서 쓰는 엑세스토큰으로 해보고 안되면 리프레쉬토큰 만들기
+      //^ 애플 소셜로그인 회원의 탈퇴 경우만 request에서 토큰 받아오기
       const clientSecret = jwtHandler.createAppleJWT();
-      const authorizationCode = code;
       const accessToken = token;
 
       const data = {
@@ -218,20 +216,22 @@ const deleteUser = async (refreshToken: string, code?: string, token?: string) =
           },
         })
         .then(async (res) => {
-          console.log("애플 회원탈퇴 성공");
+          if (res.status == 200) {
+            console.log("애플 회원탈퇴 성공");
+          }
         })
         .catch((error) => {
           console.log("애플 회원탈퇴 실패", error);
-          throw 400;
+          return rm.WITHDRAW_APPLE_SOCIAL_FAIL;
         });
     }
-    /*
+
     const data = await prisma.user.delete({
       where: {
         id: user?.id,
       },
     });
-    return data.id;*/
+    return data.id;
   } catch (error) {
     if (error instanceof PrismaClientKnownRequestError && error.code == "P2025") {
       return rm.NO_USER;


### PR DESCRIPTION
<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---

<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->
closes #147 


### 🤔 어떻게 이슈를 해결했나요?

---

- 삭제할 유저의 provider가 APPLE일때
- 먼저 애플의 키를 통해 client_secret를 만들고
- client_secret과 requset hearder를 통해 받아오는 appleAccessToken을 사용해 애플에 접속해 소셜토큰을 해지한다
- 이후 다른 소셜로그인 유저와 마찬가지로 런넥트 디비에서 유저 정보를 삭제한다.

### 🤯 주의할 점이 있나요?

---

<!-- 수정/추가한 내용중 주의깊게 봐야하는 부분이 있다면, 스크린샷으로 해당 부분을 자세히 설명해주세요. 그리고 왜 그렇게 변경했는지도 써주세요  -->
