### PR TITLE
[Feat] addPagingToRecommend

### DIFF
--- a/src/constant/responseMessage.ts
+++ b/src/constant/responseMessage.ts
@@ -63,6 +63,7 @@ export default {
   UPDATE_COURSE_SUCCESS: "업로드한 코스 수정 성공",
   NO_DELETED_PUBLIC_COURSE: "삭제할 업로드된 코스가 존재하지 않습니다.",
   READ_PUBLIC_COURSE_FAIL: "업로드된 코스 조회 실패",
+  INVALID_PAGE_NUMBER: "유효하지 않은 페이지 번호입니다.",
 
   //record
   UPLOAD_RECORD: "경로기록하기 성공",

--- a/src/controller/publicCourseController.ts
+++ b/src/controller/publicCourseController.ts
@@ -127,7 +127,9 @@ const recommendPublicCourse = async (req: Request, res: Response) => {
   // countPerPage -> 페이지 크기(한 페이지에 몇 개의 데이터)
   const pageSize = 24; // 24개씩 넘겨줌
   // pageNo -> 페이지 번호(몇 번 페이지)
-  const pageNo = parseInt(req.query.pageNo as string);
+  let pageNo = parseInt(req.query.pageNo as string);
+  // 페이지번호가 요청으로 들어오지 않을시 자동으로 1번 req
+  if (!pageNo) pageNo = 1;
 
   try {
     const recommendedPublicCourse = await publicCourseService.recommendPublicCourse(userId, pageSize, pageNo);

--- a/src/controller/publicCourseController.ts
+++ b/src/controller/publicCourseController.ts
@@ -1,4 +1,4 @@
-import { PublicCourse, PublicCourseGetDTO, PublicCourseDetailGetDTO } from "../interface/DTO/publicCourse/PublicCourseGetDTO";
+import { RecommendPublicCourse, PublicCourse, PublicCourseGetDTO, PublicCourseDetailGetDTO } from "../interface/DTO/publicCourse/PublicCourseGetDTO";
 import { Request, Response } from "express";
 import { publicCourseService } from "../service";
 import { rm, sc } from "../constant";
@@ -124,14 +124,25 @@ const recommendPublicCourse = async (req: Request, res: Response) => {
   }
   const userId: number = req.body.userId;
 
+  // countPerPage -> 페이지 크기(한 페이지에 몇 개의 데이터)
+  const pageSize = 24; // 24개씩 넘겨줌
+  // pageNo -> 페이지 번호(몇 번 페이지)
+  const pageNo = parseInt(req.query.pageNo as string);
+
   try {
-    const recommendedPublicCourse = await publicCourseService.recommendPublicCourse(userId);
+    const recommendedPublicCourse = await publicCourseService.recommendPublicCourse(userId, pageSize, pageNo);
+
+    // 가지고 있는 데이터보다 더 큰 페이지 번호를 요청했을 경우
+    if (recommendedPublicCourse == "invalidPageNo") {
+      return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.INVALID_PAGE_NUMBER));
+    }
 
     if (!recommendedPublicCourse) {
       return res.status(sc.BAD_REQUEST).send(fail(sc.BAD_REQUEST, rm.READ_PUBLIC_COURSE_FAIL));
     } else {
-      const publicCourses: PublicCourse[] = recommendedPublicCourse.map((rbc) => {
-        const pc: PublicCourse = {
+      const publicCourses: RecommendPublicCourse[] = recommendedPublicCourse.map((rbc) => {
+        const pc: RecommendPublicCourse = {
+          pageNo: pageNo,
           id: rbc.id,
           courseId: rbc.course_id,
           title: rbc.title,

--- a/src/interface/DTO/publicCourse/PublicCourseGetDTO.ts
+++ b/src/interface/DTO/publicCourse/PublicCourseGetDTO.ts
@@ -41,3 +41,16 @@ export interface PublicCourseDetailGetDTO {
     };
   };
 }
+
+export interface RecommendPublicCourse {
+  pageNo: number;
+  id: number;
+  courseId: number;
+  title: string;
+  image: string;
+  scrap?: boolean;
+  departure: {
+    region: string;
+    city: string;
+  };
+}

--- a/src/router/publicCourseRouter.ts
+++ b/src/router/publicCourseRouter.ts
@@ -30,6 +30,9 @@ publicCourseRouter.get(
       .withMessage("유저 아이디가 없습니다.")
       .isNumeric()
       .withMessage("유저아이디가 숫자가 아닙니다."),
+    query("pageNo")
+      .notEmpty()
+      .withMessage("페이지 번호가 없습니다."),
   ],
   publicCourseController.recommendPublicCourse
 );

--- a/src/router/publicCourseRouter.ts
+++ b/src/router/publicCourseRouter.ts
@@ -30,9 +30,6 @@ publicCourseRouter.get(
       .withMessage("유저 아이디가 없습니다.")
       .isNumeric()
       .withMessage("유저아이디가 숫자가 아닙니다."),
-    query("pageNo")
-      .notEmpty()
-      .withMessage("페이지 번호가 없습니다."),
   ],
   publicCourseController.recommendPublicCourse
 );

--- a/src/service/publicCourseService.ts
+++ b/src/service/publicCourseService.ts
@@ -170,8 +170,23 @@ const getPublicCourseDetail = async (userId: number, publicCourseId: number) => 
   }
 };
 
-const recommendPublicCourse = async (userId: number) => {
+const recommendPublicCourse = async (userId: number, pageSize: number, pageNo: number) => {
   try {
+    let start = 0;
+
+    if (pageNo <= 0) {
+      // 1페이지 이하의 페이지를 요청하면 1페이지를 요청한 것으로 간주
+      pageNo = 1;
+    } else {
+      start = (pageNo - 1) * pageSize;
+    }
+
+    // 가지고 있는 데이터보다 더 많은 페이지 수를 요청했을 때 -> invalid page number 리턴
+    const cnt = await prisma.publicCourse.count();
+    if (start >= cnt) {
+      return "invalidPageNo";
+    }
+
     const data = await prisma.publicCourse.findMany({
       include: {
         _count: {
@@ -189,6 +204,8 @@ const recommendPublicCourse = async (userId: number) => {
           _count: "desc",
         },
       },
+      skip: start,
+      take: pageSize,
     });
 
     return data;


### PR DESCRIPTION
feat #191

<!-- pr 이름은 '[컨벤션] 기능이름' 으로 이슈와 통일해주세요. 이슈와 마찬가지로 라벨로 담장자를  표시해 주세요. ex. [Feat] searchPublicCourse -->

### 😶 무슨 이슈인가요?

---
closes #191 
기존 recommendPublicCourse API에 page nation 기능을 추가했습니다.
<!-- 해당 pr과 연결된 이슈를 닫아주세요. closes #이슈넘버 -->

### 🤔 어떻게 이슈를 해결했나요?

---

- publicCourseController / recommendPublicCourse
   - 하나의 페이지에 24개의 코스를 넘겨주도록 설정했습니다. (pageSize변수)
   - 만약 request query에 pageNo을 포함하지 않으면 자동으로 1페이지를 리턴하도록 했습니다.

- publicCourseService / recommendPublicCourse
   - cnt 변수에 publicCourse테이블의 데이터 개수를 담고, 이것보다 요청한 페이지 수가 크면 에러 처리 하도록 했습니다.
   - prisma 쿼리문(?)에서 skip은 건너뛸 데이터의 개수이고, take는 취할 데이터의 개수입니다. 예를 들어 skip=3, take=4일 때는 앞에서 3개의 데이터를 건너뛰고 4번째 데이터부터 4개의 데이터를 불러온다(4,5,6,7번째 데이터들)는 뜻입니다.
![image](https://github.com/Runnect/Runnect-Server/assets/87180069/adadcef2-5407-4dec-a6c9-b24b28efde86)

-  DTO / publicCourseGetDTO
   - RecommendPublicCourse DTO를 새로 작성하였습니다. -> 기존에 있던 publicCourseGetDTO/publicCourse를 사용하려 했으나 pageNo추가 시 recommendPublicCourse api가 아닌 다른 api의 response에도 영향을 주게 되어 새로 작성하였습니다.

### 🤯 주의할 점이 있나요?

---
![image](https://github.com/Runnect/Runnect-Server/assets/87180069/60fbf28a-8109-4a80-aef9-439c995e7ccf)

publicCourseService에서 이 로직에 의문을 가질 수 있을 것 같은데, 해당 코드의 의미를 잠깐 설명하겠습니다. 
start는 리턴할 데이터의 시작 번호입니다. 즉, start=3이면 전체 데이터 중에서 4번째(0,1,2번 데이터를 지나 3번 데이터를 리턴) 데이터부터 리턴하는 것이죠.
만약 요청한 pageNo이 0 이하일 때는 1번 페이지를 요청한 것으로 간주하여 pageNo을 1로 바꾸고 start는 처음 선언한 그대로 0부터 시작합니다.
만약 pageNo이 1 이상일 때는 start가 (pageNo - 1) * pageSize이 되는데, 이 수식의 의미는 이전 페이지의 마지막 데이터의 번호입니다. 예를 들어 요청한 페이지가 2이고 pageSize가 3이라면 start = 3이 되겠네요. 즉, 3개의 데이터를 건너뛰고 4번째 데이터부터 반환하겠다는 뜻입니다!!!


### Request
#### 페이지 번호를 request query로 넘겨줬을 때
![image](https://github.com/Runnect/Runnect-Server/assets/87180069/86ec649e-3c18-47a1-b972-3e2411f0fd6c)
#### 페이지 번호를 넘겨주지 않았을 때
![image](https://github.com/Runnect/Runnect-Server/assets/87180069/de95f99a-b530-4bd4-80e8-761c8bb776d6)


### Response
![image](https://github.com/Runnect/Runnect-Server/assets/87180069/784487ef-0931-406d-8725-9fcb3e6d6564)
